### PR TITLE
transit.whitelight cornerplot

### DIFF
--- a/excalibur/cerberus/forward_model.py
+++ b/excalibur/cerberus/forward_model.py
@@ -424,7 +424,7 @@ def gettau(
     # dzprime = np.array(dz)
     # zprime = z
     # dzprime = dz
-    for iz, thisz in enumerate(z):
+    for thisz in z:
         # print()
         # if isinstance(thisz, tensor.variable.TensorVariable):
         #    print('LOOP iz,thisz', iz, thisz.eval(), 'TENSOR')

--- a/excalibur/cerberus/forward_model.py
+++ b/excalibur/cerberus/forward_model.py
@@ -143,7 +143,7 @@ def crbmodel(
     pgrid = np.exp(pgrid)
     # dp = np.diff(pgrid[::-1])
     p = pgrid[::-1]
-    print('pressure', len(p), p)
+    # print('pressure', len(p), p)
     # print('delta-pressure',len(dp),dp)
     dPoverP = (p[1] - p[0]) / p[0]
 
@@ -425,11 +425,11 @@ def gettau(
     # zprime = z
     # dzprime = dz
     for iz, thisz in enumerate(z):
-        print()
-        if isinstance(thisz, tensor.variable.TensorVariable):
-            print('LOOP iz,thisz', iz, thisz.eval(), 'TENSOR')
-        else:
-            print('LOOP iz,thisz', iz, thisz)
+        # print()
+        # if isinstance(thisz, tensor.variable.TensorVariable):
+        #    print('LOOP iz,thisz', iz, thisz.eval(), 'TENSOR')
+        # else:
+        #    print('LOOP iz,thisz', iz, thisz)
         # dltemp = (rp0 + zprime + dzprime)**2 - (rp0 + thisz)**2
         # print('rp0',rp0)
         # print('zprime',zprime)  # messed up.  first element (zero) is diff
@@ -582,7 +582,7 @@ def gettau(
         # print(' dl0 old', dl0.eval()/dz.eval())
         # dl0 = np.sqrt(np.max([zprime*0,(rp0 + zprime)**2 - (rp0 + thisz)**2])) # fails
         if isinstance(thisz, tensor.variable.TensorVariable):
-            print('  TENSOR YES')
+            # print('  TENSOR YES')
             dl = np.sqrt(
                 tensor.max(
                     [zprime * 0, (rp0 + zprime + dz) ** 2 - (rp0 + thisz) ** 2],
@@ -596,7 +596,7 @@ def gettau(
                 )
             )
         else:
-            print('  TENSOR NO ')
+            # print('  TENSOR NO ')
             dl = np.sqrt(
                 np.max(
                     [zprime * 0, (rp0 + zprime + dz) ** 2 - (rp0 + thisz) ** 2],
@@ -612,10 +612,10 @@ def gettau(
         # print(' dl1 ', dl.eval() / dz.eval())
         # print(' dl0 ', dl0.eval() / dz.eval())
         dl = dl - dl0
-        if isinstance(dl, tensor.variable.TensorVariable):
-            print(' dl new', dl.eval() / dz.eval())
-        else:
-            print(' dl new', dl / dz)
+        # if isinstance(dl, tensor.variable.TensorVariable):
+        #    print(' dl new', dl.eval() / dz.eval())
+        # else:
+        #    print(' dl new', dl / dz)
 
         # dl = ifelse(zprime > thisz, dl - dl0, dl * 0)  # fails
         # print('dl with nan fixed?',dl.eval())
@@ -643,7 +643,7 @@ def gettau(
             dlarraymod.append(dla.eval())
         dlarray = np.array(dlarraymod)
 
-    print('dlarray up top', dlarray)
+    # print('dlarray up top', dlarray)
 
     # GAS ARRAY, ZPRIME VERSUS WAVELENGTH  -------------------------------------------
     for elem in mixratio:
@@ -869,10 +869,10 @@ def gettau(
     # print('OVERALL TAU!!!', tau.eval())
 
     # any trouble with this matrix multiplication?
-    print('dlarray', dlarray)
-    print('dlarray', dlarray.shape)  # 7x7 elements
-    print('dlarray[0][0]', dlarray[0][0])
-    print('tau', tau.eval().shape)  # 7x103 elements
+    # print('dlarray', dlarray)
+    # print('dlarray', dlarray.shape)  # 7x7 elements
+    # print('dlarray[0][0]', dlarray[0][0])
+    # print('tau', tau.eval().shape)  # 7x103 elements
 
     # module 'pytensor.tensor' has no attribute 'as_matrix'. Did you mean: 'bmatrix'?
     #    tau = 2e0 * np.array(tensor.as_matrix(dlarray) * tensor.as_matrix(tau))

--- a/excalibur/system/autofill.py
+++ b/excalibur/system/autofill.py
@@ -68,7 +68,7 @@ def fillUncertainty(param, param_value, param_uncertainty, error_type):
                 fillvalue = 0.1
                 fillvalue = 0.2
                 fillvalue = 0.3  # 90-percentile; 95-percentile is 0.3
-            elif param == 'Hmag' or param == 'Jmag' or param == 'Kmag':
+            elif param in ['Hmag', 'Jmag', 'Kmag']:
                 # 0.1 dex for J,H,K band magnitudes
                 # offenders: Kepler-1651, TOI-2583 A, TOI-3976 A, WASP-193
                 fillvalue = 0.1

--- a/excalibur/system/autofill.py
+++ b/excalibur/system/autofill.py
@@ -68,8 +68,9 @@ def fillUncertainty(param, param_value, param_uncertainty, error_type):
                 fillvalue = 0.1
                 fillvalue = 0.2
                 fillvalue = 0.3  # 90-percentile; 95-percentile is 0.3
-            elif param == 'Hmag':
-                # 0.1 dex for H band magnitude (for Kepler-1651)
+            elif param == 'Hmag' or param == 'Jmag' or param == 'Kmag':
+                # 0.1 dex for J,H,K band magnitudes
+                # offenders: Kepler-1651, TOI-2583 A, TOI-3976 A, WASP-193
                 fillvalue = 0.1
             elif param == 'period':
                 # orbital period should be known pretty well. how about 1%?
@@ -127,6 +128,10 @@ def fillUncertainty(param, param_value, param_uncertainty, error_type):
                 fillvalue = float(param_value) * 0.2
             elif param == 'trandur':
                 # transit duration to 20%? S/N=5 seems reasonable I guess
+                fillvalue = float(param_value) * 0.2
+            elif param == 'dist':
+                # 20% for distance, I guess
+                # offenders: WASP-103, WASP-105, WASP-20. HATS-58, HATS-12, K2-238
                 fillvalue = float(param_value) * 0.2
             else:
                 # fallback option is to set uncertainty to 10%

--- a/excalibur/transit/algorithms.py
+++ b/excalibur/transit/algorithms.py
@@ -239,6 +239,9 @@ class WhiteLight(dawgie.Algorithm):
                 pass
             if allnormdata:
                 try:
+                    log.warning(
+                        '--< %s WHITELIGHT: HST >--', self._type.upper()
+                    )
                     update = self._hstwhitelight(
                         allnormdata,
                         fin,
@@ -264,7 +267,7 @@ class WhiteLight(dawgie.Algorithm):
             vnrm, snrm = checksv(nrm)
             if vnrm and vfin:
                 log.warning(
-                    '--< %s WHITE LIGHT: %s >--', self._type.upper(), fltr
+                    '--< %s WHITELIGHT: %s >--', self._type.upper(), fltr
                 )
                 update = self._whitelight(
                     nrm,

--- a/excalibur/transit/core.py
+++ b/excalibur/transit/core.py
@@ -1627,6 +1627,16 @@ def hstwhitelight(
         out['data'][p]['allfltrs'] = allfltrs
         out['data'][p]['allttvs'] = allttvs
         out['STATUS'].append(True)
+
+        # SAVE A CORNER PLOT BASED ON TRANSIT.WHITELIGHT PYMC FITTING - HST COMBO
+        prior_ranges = None
+        out['data'][p]['plot_corner'] = plot_corner(
+            mctrace,
+            prior_ranges,
+            p,
+            savetodisk=False,
+        )
+
     return True
 
 
@@ -1854,9 +1864,6 @@ def whitelight(
                 lower=rpors / 2e0,
                 upper=2e0 * rpors,
             )
-            print('PRIOR rprs', rpors, taurprs, rpors / 2e0, 2e0 * rpors)
-            print('PRIOR rprs range', 2e0 * rpors - rpors / 2e0)
-            print('PRIOR rprs range/3', (2e0 * rpors - rpors / 2e0) / 3)
             nodes.append(rprs)
             if parentprior:
                 # use parent distr fitted Lorentzians (also called Cauchy)
@@ -2048,14 +2055,11 @@ def whitelight(
         wl = True
 
         # SAVE A CORNER PLOT BASED ON TRANSIT.WHITELIGHT PYMC FITTING
-
         out['data'][p]['plot_corner'] = plot_corner(
-            # all_keys,
             mctrace,
-            # bestfit_params,
             prior_ranges,
             p,
-            savetodisk=True,
+            savetodisk=False,
         )
 
     return wl

--- a/excalibur/transit/plotters.py
+++ b/excalibur/transit/plotters.py
@@ -24,119 +24,97 @@ log = logging.getLogger(__name__)
 
 
 def plot_corner(
-    # allkeys,
     alltraces,
-    # modelParams_bestFit,
     prior_ranges,
     p,
-    saveDir=os.path.join(excalibur.context['data_dir'], 'bryden/'),
+    saveDir=os.path.join(excalibur.context['data_dir'], 'debug/'),
     savetodisk=False,
 ):
     '''corner plot showing posterior distributions (transit, not cerberus)'''
 
     fitcolor = 'firebrick'
 
-    allkeys = []
+    fit_param_names = []
     modelParams_bestFit = []
+    chainlen = 0
+    numwalkers = 0
     for key, values in alltraces.items():
-        allkeys.append(key)
+        fit_param_names.append(key)
         modelParams_bestFit.append(np.nanmedian(values))
-        print(
-            'WHITELIGHT trace median,std,min,max',
-            key,
-            np.nanmedian(values),
-            np.nanstd(values),
-            np.nanmin(values),
-            np.nanmax(values),
-        )
+        chainlen = max(chainlen, len(values[0]))
+        numwalkers = max(numwalkers, len(values[:, 0]))
+        # print(
+        #    'WHITELIGHT trace median,std,min,max',
+        #    key,
+        #    np.nanmedian(values),
+        #    np.nanstd(values),
+        #    np.nanmin(values),
+        #    np.nanmax(values),
+        # )
+    # print('chainlen,numwalkers', chainlen, numwalkers)
 
-    print(' params inside of corner plotting', allkeys)
+    # print('mctrace params', alltraces.keys())
+    # print(' params inside of corner plotting', fit_param_names)
+    # place rprs as the first parameters? asdf
 
-    print('mctrace params', alltraces.keys())
+    # print('bestfit values passed in (currently median)', modelParams_bestFit)
+    # print()
 
-    print('bestfit values passed in (currently median)', modelParams_bestFit)
-    print()
-
-    lo = []
-    hi = []
-    priorlo = []
-    priorhi = []
-    mcmcMedian = []
-    # awkward because alltraces is a dictionary
-    #  convert to 2-d array first (needed for corner() anyway)
-    paramnames = []
+    #  convert to the tracearray to a 2-d array (corner() format)
     tracearray = []
     for param, values in alltraces.items():
-        paramnames.append(param)
-        tracearray.append(values)
-        print('shape added', param, values.shape)
-    print('tracearray', tracearray)
+        # fixed parameters only have 2 steps. extend them
+        if len(values[0]) < chainlen:
+            # print('EXTENDING A FIXED PARAM', param, numwalkers, chainlen)
+            tracearray.append(
+                float(values[0][0]) * np.ones((numwalkers, chainlen))
+            )
+        else:
+            tracearray.append(np.array(values))
     tracearray = np.array(tracearray)
 
-    for param, values in alltraces.items():
-        mcmcMedian.append(np.nanmedian(values))
-        lo.append(np.nanpercentile(np.array(values), 16))
-        hi.append(np.nanpercentile(np.array(values), 84))
-        # span = hi - lo
-        # Careful! these are not actually the prior ranges;
-        #  they're the range of walker values (unless set below)
-        priorlo.append(np.nanmin(values))
-        priorhi.append(np.nanmax(values))
-    print('medians inside of corner plotting', mcmcMedian)
-
-    mcmcMedian = np.nanmedian(tracearray, axis=1)
-    lo = np.nanpercentile(np.array(tracearray), 16, axis=1)
-    hi = np.nanpercentile(np.array(tracearray), 84, axis=1)
-    # span = hi - lo
+    mcmcMedian = np.nanmedian(tracearray, axis=(1, 2))
     # Careful! these are not actually the prior ranges;
     #  they're the range of walker values (unless set below)
-    priorlo = np.nanmin(tracearray, axis=1)
-    priorhi = np.nanmax(tracearray, axis=1)
-    print('medians inside of corner plotting', mcmcMedian)
-    print()
-    print()
+    priorlo = np.nanmin(tracearray, axis=(1, 2))
+    priorhi = np.nanmax(tracearray, axis=(1, 2))
+    # print('medians inside of corner plotting', mcmcMedian)
+    # print('  priorlo', priorlo)
 
-    for ikey, key in enumerate(allkeys):
-        print('param:', ikey, key)
-        print('  old prior range:', key, priorlo[ikey], priorhi[ikey])
+    # for cases with fixed params, make sure the plots have some range
+    #  actually this is not needed. corner() can handle it
+
+    for ikey, key in enumerate(fit_param_names):
         if key in prior_ranges.keys():
+            # print(
+            #    '  old prior range (median):', key, priorlo[ikey], priorhi[ikey]
+            # )
             priorlo[ikey] = prior_ranges[key][0]
             priorhi[ikey] = prior_ranges[key][1]
-        else:
-            print('  TROUBLE: ', key, 'not found in', prior_ranges.keys())
-        print('  new prior range:', key, priorlo[ikey], priorhi[ikey])
-    # priorspan = priorhi - priorlo
-    # priormid = (priorhi + priorlo) / 2.
-
-    lodist = np.array(mcmcMedian) - np.array(lo)
-    hidist = np.array(hi) - np.array(mcmcMedian)
-    lorange = np.array(mcmcMedian) - 3 * lodist
-    hirange = np.array(mcmcMedian) + 3 * hidist
-    trange = [tuple([x, y]) for x, y in zip(lorange, hirange)]
-    # previous lines did 3-sigma range.  better to just use the prior bounds as bounds
+            # print(
+            #    '  new prior range (true)  :', key, priorlo[ikey], priorhi[ikey]
+            # )
     trange = [tuple([x, y]) for x, y in zip(priorlo, priorhi)]
-    # print('trange',trange)
-    # print('lodist',lodist)
-    # print('lorange',lorange)
+
     figure = corner.corner(
-        np.vstack(np.array(tracearray)).T,
+        np.vstack(np.array(tracearray).T),
         bins=10,
-        labels=allkeys,
+        labels=fit_param_names,
         range=trange,
         show_titles=True,
         quantiles=[0.16, 0.50, 0.84],
     )
 
-    ndim = len(allkeys)
+    ndim = len(fit_param_names)
     axes = np.array(figure.axes).reshape((ndim, ndim))
     # use larger font size for the axis labels
     for i in range(ndim):
         ax = axes[ndim - 1, i]
-        ax.set_xlabel(allkeys[i], fontsize=14)
+        ax.set_xlabel(fit_param_names[i], fontsize=14)
     for i in range(ndim - 1):
         # skipping the first one on the y side (it's a histo, not a 2-D plot)
         ax = axes[i + 1, 0]
-        ax.set_ylabel(allkeys[i + 1], fontsize=14)
+        ax.set_ylabel(fit_param_names[i + 1], fontsize=14)
     #  draw a point and crosshair for the medians in each subpanel
     for yi in range(ndim):
         for xi in range(yi):
@@ -159,6 +137,8 @@ def plot_corner(
         ax.axvline(modelParams_bestFit[i], color=fitcolor, lw=2, zorder=12)
 
     if savetodisk:
+        saveDir = '/proj/sdp/data/debug/'
+        # print('  Saving figure to disk!',saveDir+'corner-'+p+'.png')
         plt.savefig(saveDir + 'corner-' + p + '.png')
 
     return save_plot_tosv(figure), figure

--- a/excalibur/transit/plotters.py
+++ b/excalibur/transit/plotters.py
@@ -62,7 +62,7 @@ def plot_corner(
 
     #  convert to the tracearray to a 2-d array (corner() format)
     tracearray = []
-    for param, values in alltraces.items():
+    for _, values in alltraces.items():
         # fixed parameters only have 2 steps. extend them
         if len(values[0]) < chainlen:
             # print('EXTENDING A FIXED PARAM', param, numwalkers, chainlen)
@@ -73,12 +73,10 @@ def plot_corner(
             tracearray.append(np.array(values))
     tracearray = np.array(tracearray)
 
-    mcmcMedian = np.nanmedian(tracearray, axis=(1, 2))
     # Careful! these are not actually the prior ranges;
     #  they're the range of walker values (unless set below)
     priorlo = np.nanmin(tracearray, axis=(1, 2))
     priorhi = np.nanmax(tracearray, axis=(1, 2))
-    # print('medians inside of corner plotting', mcmcMedian)
     # print('  priorlo', priorlo)
 
     # for cases with fixed params, make sure the plots have some range
@@ -119,9 +117,6 @@ def plot_corner(
     for yi in range(ndim):
         for xi in range(yi):
             ax = axes[yi, xi]
-            # ax.axvline(mcmcMedian[xi], color=fitcolor)
-            # ax.axhline(mcmcMedian[yi], color=fitcolor)
-            # ax.plot(mcmcMedian[xi], mcmcMedian[yi], marker='s', c=fitcolor)
             ax.axvline(modelParams_bestFit[xi], color=fitcolor)
             ax.axhline(modelParams_bestFit[yi], color=fitcolor)
             ax.plot(

--- a/excalibur/transit/states.py
+++ b/excalibur/transit/states.py
@@ -87,13 +87,13 @@ class WhiteLightSV(ExcaliburSV):
             if 'HST' in self.name():
                 mergesv = bool(self.name() == 'HST')
                 for p in self['data'].keys():
-                    visits = np.array(self['data'][p]['visits'])
+                    visits = self['data'][p]['visits']
                     # phase,allwhite is the data before shifting
-                    phase = np.array(self['data'][p]['phase'])
-                    allwhite = np.array(self['data'][p]['allwhite'])
+                    phase = self['data'][p]['phase']
+                    allwhite = self['data'][p]['allwhite']
                     # postphase,allwhite/postim is the data after shifting
-                    postphase = np.array(self['data'][p]['postphase'])
-                    postim = np.array(self['data'][p]['postim'])
+                    postphase = self['data'][p]['postphase']
+                    postim = self['data'][p]['postim']
                     # phase,postlc is the model
                     postflatphase = np.array(self['data'][p]['postflatphase'])
                     postlc = np.array(self['data'][p]['postlc'])
@@ -120,8 +120,8 @@ class WhiteLightSV(ExcaliburSV):
                         else:
                             vlabel = 'visit ' + str(v)
                         ax1.plot(
-                            postphase[index],
-                            allwhite[index] / postim[index],
+                            np.array(postphase[index]),
+                            np.array(allwhite[index]) / np.array(postim[index]),
                             'o',
                             zorder=3,
                             label=vlabel,
@@ -130,16 +130,16 @@ class WhiteLightSV(ExcaliburSV):
                         # plot the pre-correction data
                         if index == len(visits) - 1:
                             ax1.plot(
-                                phase[index],
-                                allwhite[index],
+                                np.array(phase[index]),
+                                np.array(allwhite[index]),
                                 'k+',
                                 zorder=2,
                                 label='pre-correction',
                             )
                         else:
                             ax1.plot(
-                                phase[index],
-                                allwhite[index],
+                                np.array(phase[index]),
+                                np.array(allwhite[index]),
                                 'k+',
                                 zorder=2,
                             )
@@ -152,15 +152,15 @@ class WhiteLightSV(ExcaliburSV):
                             fill_value='extrapolate',
                         )
                         model_at_observed_time = model_interpolator(
-                            postphase[index]
+                            np.array(postphase[index])
                         )
                         residuals = (
-                            allwhite[index] / postim[index]
+                            np.array(allwhite[index]) / np.array(postim[index])
                             - model_at_observed_time
                         )
 
                         ax2.plot(
-                            postphase[index],
+                            np.array(postphase[index]),
                             residuals,
                             'o',
                             color='black',


### PR DESCRIPTION
Cleaning up some bugs from last PR, plus some new ones.

- edit transit.whitelight corner plot so it can handle fixed parameters
- also make a corner plot for hstwhitelight (the combined HST lightcurve)
- multi-visit transit.whitelight plots are crashing when different length lists are tried to turn into a 2-d array; edit transit/states to only do np.array() on the each 1-d part, not over all visits
- some target parameters are strangely missing uncertainties; sys.autofill updated
