### PR TITLE
Cerberus pymc testing

### DIFF
--- a/excalibur/cerberus/algorithms.py
+++ b/excalibur/cerberus/algorithms.py
@@ -500,7 +500,7 @@ class Release(dawgie.Algorithm):
         '''__init__ ds'''
         self._version_ = crbcore.rlsversion()
         self.__fin = sysalg.Finalize()
-        self.__atm = Atmos()
+        # self.__atm = Atmos()
         self.__out = [crbstates.RlsSv(fltr) for fltr in fltrs]
         return
 

--- a/excalibur/cerberus/algorithms.py
+++ b/excalibur/cerberus/algorithms.py
@@ -341,7 +341,7 @@ class Results(dawgie.Algorithm):
             # for fltr in ['HST-WFC3-IR-G141-SCAN']:
             # for fltr in ['Ariel-sim']:
             for fltr in self.__rt.sv_as_dict()['status'][
-                    'allowed_filter_names'
+                'allowed_filter_names'
             ]:
                 # stop here if it is not a runtime target
                 self.__rt.proceed(fltr)

--- a/excalibur/cerberus/algorithms.py
+++ b/excalibur/cerberus/algorithms.py
@@ -189,6 +189,7 @@ class Atmos(dawgie.Algorithm):
         svupdate = []
         # just one filter, while debugging:
         # for fltr in ['HST-WFC3-IR-G141-SCAN']:
+        # for fltr in ['Ariel-sim']:
         for fltr in self.__rt.sv_as_dict()['status']['allowed_filter_names']:
             # stop here if it is not a runtime target
             self.__rt.proceed(fltr)
@@ -257,6 +258,7 @@ class Atmos(dawgie.Algorithm):
         mcmc_chain_length = runtime_params.MCMC_chain_length.value()
         # print('MCMC_chain_length', mcmc_chain_length)
         # mcmc_chain_length = 1000
+        # mcmc_chain_length = 10
         # print('MCMC_chain_length', mcmc_chain_length)
         log.info(
             ' calling atmos from cerb-alg-atmos  chain len=%d',
@@ -337,8 +339,9 @@ class Results(dawgie.Algorithm):
 
             # just one filter, while debugging:
             # for fltr in ['HST-WFC3-IR-G141-SCAN']:
+            # for fltr in ['Ariel-sim']:
             for fltr in self.__rt.sv_as_dict()['status'][
-                'allowed_filter_names'
+                    'allowed_filter_names'
             ]:
                 # stop here if it is not a runtime target
                 self.__rt.proceed(fltr)
@@ -507,10 +510,10 @@ class Release(dawgie.Algorithm):
 
     def previous(self):
         '''Input State Vectors: cerberus.atmos'''
-        return [
-            dawgie.ALG_REF(sys.task, self.__fin),
-            dawgie.ALG_REF(fetch('excalibur.cerberus').task, self.__atm),
-        ]
+        return []
+        #    dawgie.ALG_REF(sys.task, self.__fin),
+        #    dawgie.ALG_REF(fetch('excalibur.cerberus').task, self.__atm),
+        # ]
 
     def state_vectors(self):
         '''Output State Vectors: cerberus.release'''

--- a/excalibur/transit/algorithms.py
+++ b/excalibur/transit/algorithms.py
@@ -79,6 +79,9 @@ class Normalization(dawgie.Algorithm):
 
         svupdate = []
         vfin, sfin = checksv(self.__fin.sv_as_dict()['parameters'])
+
+        # just one filter, while debugging:
+        # for fltr in ['HST-WFC3-IR-G141-SCAN']:
         for fltr in self.__rt.sv_as_dict()['status']['allowed_filter_names']:
             # stop here if it is not a runtime target
             self.__rt.proceed(fltr)
@@ -240,7 +243,7 @@ class WhiteLight(dawgie.Algorithm):
             if allnormdata:
                 try:
                     log.warning(
-                        '--< %s WHITELIGHT: HST >--', self._type.upper()
+                        '--< %s WHITELIGHT: HSTCOMBO >--', self._type.upper()
                     )
                     update = self._hstwhitelight(
                         allnormdata,
@@ -260,7 +263,10 @@ class WhiteLight(dawgie.Algorithm):
                     )
                     pass
                 pass
+
         # FILTER LOOP
+        # just one filter, while debugging:
+        # for fltr in ['HST-WFC3-IR-G141-SCAN']:
         for fltr in self.__rt.sv_as_dict()['status']['allowed_filter_names']:
             update = False
             nrm = self._nrm.sv_as_dict()[fltr]
@@ -292,8 +298,6 @@ class WhiteLight(dawgie.Algorithm):
 
     def _hstwhitelight(self, nrm, fin, chain_length, out, fltr):
         '''Core code call for merged HST data'''
-        # chain_length = 10
-        # print('chain length in hstwhitelight',chain_length)
 
         wl = trncore.hstwhitelight(
             nrm,
@@ -308,8 +312,6 @@ class WhiteLight(dawgie.Algorithm):
 
     def _whitelight(self, nrm, fin, chain_length, out, fltr):
         '''Core code call'''
-        # chain_length = 10
-        # print('chain length in whitelight',chain_length)
 
         if 'Spitzer' in fltr:
             wl = trncore.lightcurve_spitzer(
@@ -390,6 +392,8 @@ class Spectrum(dawgie.Algorithm):
         svupdate = []
         vfin, sfin = checksv(self.__fin.sv_as_dict()['parameters'])
 
+        # just one filter, while debugging:
+        # for fltr in ['HST-WFC3-IR-G141-SCAN']:
         for fltr in self.__rt.sv_as_dict()['status']['allowed_filter_names']:
             # stop here if it is not a runtime target
             self.__rt.proceed(fltr)
@@ -482,12 +486,13 @@ class StarSpots(dawgie.Algorithm):
         return 'starspots'
 
     def previous(self):
-        '''Input State Vectors: system.finalize, transit.normalization,
-        transit.whitelight'''
-        return [
-            dawgie.ALG_REF(sys.task, self.__fin),
-            dawgie.ALG_REF(fetch('excalibur.transit').task, self._spc),
-        ] + self.__rt.refs_for_proceed()
+        '''
+        Input State Vectors: system.finalize, transit.spectrum
+        '''
+        return []
+        #    dawgie.ALG_REF(sys.task, self.__fin),
+        #    dawgie.ALG_REF(fetch('excalibur.transit').task, self._spc),
+        # ] + self.__rt.refs_for_proceed()
 
     def state_vectors(self):
         '''Output State Vectors: transit.starspots'''
@@ -500,7 +505,7 @@ class StarSpots(dawgie.Algorithm):
         vfin, sfin = checksv(self.__fin.sv_as_dict()['parameters'])
 
         # print('STARSPOTS: allowed filters',
-        #    self.__rt.sv_as_dict()['status']['allowed_filter_names'])
+        #      self.__rt.sv_as_dict()['status']['allowed_filter_names'])
 
         # for fltr in ['HST-WFC3-IR-G141-SCAN']:  # for debugging, just run G141
         for fltr in self.__rt.sv_as_dict()['status']['allowed_filter_names']:
@@ -509,6 +514,7 @@ class StarSpots(dawgie.Algorithm):
 
             update = False
             vspc, sspc = checksv(self._spc.sv_as_dict()[fltr])
+
             if vfin and vspc:
                 # log.warning(
                 #     '--< %s STARSPOTS: %s >--', self._type.upper(), fltr

--- a/excalibur/transit/core.py
+++ b/excalibur/transit/core.py
@@ -2863,8 +2863,10 @@ def spectrum(
                     rprs = pymc.Normal(
                         'rprs', mu=prcenter, tau=1e0 / (prwidth**2)
                     )
-                    prior_ranges['rprs'] = [prcenter - 2 * prwidth,
-                                            prcenter + 2 * prwidth]
+                    prior_ranges['rprs'] = [
+                        prcenter - 2 * prwidth,
+                        prcenter + 2 * prwidth,
+                    ]
                 allvslope = pymc.TruncatedNormal(
                     'vslope',
                     mu=0e0,

--- a/excalibur/transit/core.py
+++ b/excalibur/transit/core.py
@@ -1405,6 +1405,7 @@ def hstwhitelight(
             visits=visits,
             fixedpars=fixedpars,
         )
+        prior_ranges = {}
         with pymc.Model():
             # --< PRIORS >--
             rprs = pymc.TruncatedNormal(
@@ -1414,6 +1415,7 @@ def hstwhitelight(
                 lower=rpors / 2e0,
                 upper=2e0 * rpors,
             )
+            prior_ranges['rprs'] = [rpors / 2e0, 2e0 * rpors]
             nodes.append(rprs)
             if 'WFC3' in ext:
                 alltknot = pymc.TruncatedNormal(
@@ -1424,6 +1426,11 @@ def hstwhitelight(
                     upper=tknotmax,
                     shape=shapettv,
                 )
+                for i in range(shapettv):
+                    prior_ranges['dtk__' + str(i)] = [
+                        tknotmin,
+                        tknotmax,
+                    ]
                 nodes.append(alltknot)
                 # if fixedinc:
                 #    inc = priors[p]['inc']
@@ -1436,6 +1443,7 @@ def hstwhitelight(
                         upper=upinc,
                     )
                     nodes.append(inc)
+                    prior_ranges['inc'] = [lowinc, upinc]
                 pass
             allvslope = pymc.TruncatedNormal(
                 'vslope',
@@ -1447,6 +1455,19 @@ def hstwhitelight(
             )
             alloslope = pymc.Normal('oslope', mu=0e0, tau=tauvs, shape=shapevis)
             alloitcp = pymc.Normal('oitcp', mu=1e0, tau=tauvi, shape=shapevis)
+            for i in range(shapettv):
+                prior_ranges['vslope__' + str(i)] = [
+                    -0.02 / trdura,
+                    0.02 / trdura,
+                ]
+                prior_ranges['oslope__' + str(i)] = [
+                    -0.02 / trdura,
+                    0.02 / trdura,
+                ]
+                prior_ranges['oitcp__' + str(i)] = [
+                    1 - 2 * ootstd,
+                    1 + 2 * ootstd,
+                ]
             nodes.append(allvslope)
             nodes.append(alloslope)
             nodes.append(alloitcp)
@@ -1657,7 +1678,6 @@ def hstwhitelight(
         out['STATUS'].append(True)
 
         # SAVE A CORNER PLOT BASED ON TRANSIT.WHITELIGHT PYMC FITTING - HST COMBO
-        prior_ranges = None
         out['data'][p]['plot_corner'] = plot_corner(
             mctrace,
             prior_ranges,
@@ -1898,8 +1918,6 @@ def whitelight(
             oitcp_beta = (1 / tauvi) ** 0.5
         # PYMC --------------------------------------------------------------------------
         prior_ranges = {}
-        prior_ranges['rprs'] = [rpors / 2e0, 2e0 * rpors]
-
         with pymc.Model():
             rprs = pymc.TruncatedNormal(
                 'rprs',
@@ -1908,6 +1926,7 @@ def whitelight(
                 lower=rpors / 2e0,
                 upper=2e0 * rpors,
             )
+            prior_ranges['rprs'] = [rpors / 2e0, 2e0 * rpors]
             nodes.append(rprs)
             if parentprior:
                 # use parent distr fitted Lorentzians (also called Cauchy)
@@ -1941,6 +1960,19 @@ def whitelight(
                 alloitcp = pymc.Normal(
                     'oitcp', mu=1e0, tau=tauvi, shape=shapevis
                 )
+                for i in range(shapevis):
+                    prior_ranges['vslope__' + str(i)] = [
+                        -0.03 / trdura,
+                        0.03 / trdura,
+                    ]
+                    prior_ranges['oslope__' + str(i)] = [
+                        -0.02 / trdura,
+                        0.02 / trdura,
+                    ]
+                    prior_ranges['oitcp__' + str(i)] = [
+                        1 - 2 * ootstd,
+                        1 + 2 * ootstd,
+                    ]
             nodes.append(allvslope)
             nodes.append(alloslope)
             nodes.append(alloitcp)
@@ -2818,17 +2850,21 @@ def spectrum(
                 visits=visits,
             )
             # PYMC ----------------------------------------------------------------------
+            prior_ranges = {}
             with pymc.Model():
                 if startflag:
                     lowstart = whiterprs - 5e0 * Hs
                     lowstart = tensorfunc.max(lowstart, 0)
                     upstart = whiterprs + 5e0 * Hs
                     rprs = pymc.Uniform('rprs', lower=lowstart, upper=upstart)
+                    prior_ranges['rprs'] = [lowstart, upstart]
                     pass
                 else:
                     rprs = pymc.Normal(
                         'rprs', mu=prcenter, tau=1e0 / (prwidth**2)
                     )
+                    prior_ranges['rprs'] = [prcenter - 2 * prwidth,
+                                            prcenter + 2 * prwidth]
                 allvslope = pymc.TruncatedNormal(
                     'vslope',
                     mu=0e0,

--- a/excalibur/transit/plotters.py
+++ b/excalibur/transit/plotters.py
@@ -54,10 +54,10 @@ def plot_corner(
     #  convert to the tracearray to a 2-d array (corner() format)
     tracearray = []
     for _, values in alltraces.items():
-        tracearray.append(np.array(values))
+        tracearray.append(np.array(values).flatten())
     tracearray = np.array(tracearray)
 
-    # Careful! these are not actually the prior ranges;
+    # Careful! priorlo,priorhi are not actually the prior ranges;
     #  they're the range of walker values (unless set below)
     priorlo = np.nanmin(tracearray, axis=1)
     priorhi = np.nanmax(tracearray, axis=1)


### PR DESCRIPTION
fix corner plots in transit (traces are now 1-d rather than 2-d, for each parameter)
include prior ranges in the corner plots

turn off auto-triggered runs for transit.starspots and cerberus.release
