### PR TITLE
pushing fixes and update to scrape_regression

### DIFF
--- a/excalibur/target/algorithms.py
+++ b/excalibur/target/algorithms.py
@@ -285,16 +285,10 @@ class TargetScrapeRegression(dawgie.Regression):
     def run(self, ps: int, timeline: dawgie.Timeline):
         '''Top level algorithm call'''
 
-        data, quality_dict = trgmonitor.regress_for_frame_counts(
-            self.__out['data'][0], self.__out['quality'][0], timeline
+        # this function will edit 'data' and 'quality' in-place
+        trgmonitor.regress_for_frame_counts(
+            self.__out['data'], self.__out['quality'], timeline
         )
-
-        self.__out['data'].clear()
-        self.__out['data'].append(data)
-
-        # self.__out['quality'] = self.__out['quality'].new(quality_flag)
-        self.__out['quality'].clear()
-        self.__out['quality'].append(quality_dict)
 
         self.__out['STATUS'].append(True)
         timeline.ds().update()

--- a/excalibur/target/monitor.py
+++ b/excalibur/target/monitor.py
@@ -2,25 +2,24 @@
 
 # -- IMPORTS -- ------------------------------------------------------
 from collections import defaultdict
-
+import logging
 # ------------- ------------------------------------------------------
+
+log = logging.getLogger(__name__)
 
 
 def regress_for_frame_counts(
-    data: {int: {str: int, str: int}},
-    quality_dict: {int: int},
+    data: {int: {str: int}},
+    quality_dict: {int: {str: int, str: int}},
     tl: {str: {str: {str: object}}},
 ) -> ({str: float}, {str: []}, []):
     '''
     this functions regresses through the runids for target.scrape.databases.
-    data currently contains:
-
-    observatory-instrument-detector-filter-mode: # of occurences
-
-    timeline iterates through descending order of runID. Therefore
-    the newest runIDs go first, then code breaks once it hits a runID
-    that has already been computed.
-    #'''
+    `data` currently contains:
+    {observatory-instrument-detector-filter-mode: # of occurences}
+    `quality` currently contains:
+    {filter: {status: 1, -1}}
+    '''
 
     for rid in tl:
         if rid in data:
@@ -38,36 +37,58 @@ def regress_for_frame_counts(
                         + '-'
                         + frame_d['detector']
                         + '-'
-                        + frame_d['filter']
-                        + '-'
                     )
+                    # if filter is None: this frame was direct imaging
+                    if frame_d['filter'] is None:
+                        identifier += ''
+                    else:
+                        identifier += frame_d['filter'] + '-'
                     if frame_d['mode'] is None:
                         identifier += 'STARE'
                     else:
                         identifier += frame_d['mode']
                     data[rid][identifier] += 1
 
+    # filter: [list of frame counts]
+    history = defaultdict(list)
+
     # getting the most current frame counts and previous frames counts to compare
     sorted_keys = sorted(data.keys())
+
+    quality_dict[sorted_keys[0]] = defaultdict(int)
+
+    # unique_filter_names = set(data[sorted_keys[0]])
+    for filter in data[sorted_keys[0]]:
+        history[filter].append(data[sorted_keys[0]][filter])
+        quality_dict[sorted_keys[0]][filter] = 1
+
     # this if is redundant, will remove later
     if len(sorted_keys) > 1:
         # i know im traversing the rids again, i feel like there's a good reason
         # to do this but if i find out there isn't ill try to conslidate the loops
-        for i, rid in enumerate(sorted_keys[1:], start=1):
+        for rid in sorted_keys[1:]:
 
             # if this rid already exists in quality_dict, skip
             if rid in quality_dict:
-                print('key alr exists, continuing')
                 continue
-            # add quality flag entry for rid
-            quality_dict[rid] = 1
-            cur_frames = data[rid]
-            prev_frames = data[sorted_keys[i - 1]]
 
-            for identifier in prev_frames:
-                if identifier not in cur_frames:
-                    # checking if previously this key existed (ie, had some frames) but in current doesn't?
-                    quality_dict[rid] = -1
-                    break
+            quality_dict[rid] = defaultdict(int)
 
-    return data, quality_dict
+            for filter in data[rid]:
+                # if this filter has already been seen, and frames exist
+                # automatically status = 1
+                if filter in history:
+                    history[filter].append(data[rid][filter])
+                    quality_dict[rid][filter] = 1
+                # this is when a new filter is encountered
+                else:
+                    # status automatically 1
+                    history[filter].append(data[rid][filter])
+                    quality_dict[rid][filter] = 1
+
+            # set of filters that have been seen before but are not in this rid
+            # these are dropped/not downloaded filters, so automatically -1
+            dropped_filters = set(history).difference(set(data[rid]))
+            for filter in dropped_filters:
+                history[filter].append(0)
+                quality_dict[rid][filter] = -1


### PR DESCRIPTION
| Bug | Status | Explanation |
| --- | --- | --- |
| When target.scrape.databases are empty, the plot for databases_validation is empty. Fix this. | <ul><li>- [x] </li> |  Gael is okay with empty plots. |
| The logic of the status checker was slightly off, as Mark pointed out. | <ul><li> - [x] </li> | Previously I had a single status for the entire state vector. Gael wanted a status for each filter, so I have changed the logic to reflect that. I also changed the plot from a line graph to a heatmap, per Gael's suggestion. |
| Figure out whats happening with ValuesDict(). Switch state vector to dicts and remove list hack. | <ul><li>- [x] </li> | I was passing in data/quality, updating in place, then returning data and quality. Then, I was clearing() data/quality, then trying to assign data/quality with itself, which is now empty. TLDR; simple mistake, I fixed it with Al's help. |
|  Sometimes frame['filter'] is None. Figure out why that's happening, and add a fix. | <ul><li>- [x] </li> | Filter is none when target was direct imaged. Add a '' when that's the case |
