### PR TITLE
Updating overwriter.py for L 98-59

### DIFF
--- a/excalibur/system/overwriter.py
+++ b/excalibur/system/overwriter.py
@@ -5,7 +5,7 @@
 
 import numpy
 import copy
-import excalibur.system.core as syscore
+from importlib import import_module as fetch
 from excalibur.system.autofill import (
     derive_LOGGplanet_from_R_and_M,
     derive_Teqplanet_from_Lstar_and_sma,
@@ -58,7 +58,7 @@ def ppar():
         }
     }
     '''
-    sscmks = syscore.ssconstants(cgs=True)
+    sscmks = fetch('excalibur.system.core').ssconstants(cgs=True)
 
     overwrite = {}
     # this one is somewhat higher than bonomo (0.6).  drop here ig


### PR DESCRIPTION
Overwriting L98-59's system parameters (in system.overwriter) corresponding to the recently updated values from Cadieux et.al 2025 (rather than Demangeon et al 2021).

Data comes from exoplanet archive : https://exoplanetarchive.ipac.caltech.edu/overview/L%2098-59